### PR TITLE
use 14 as the default intellij version moving forward

### DIFF
--- a/cli/lib/cli/ide/intellij_user_pref_dir.rb
+++ b/cli/lib/cli/ide/intellij_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "13"
+        "14"
       end
     end
   end

--- a/cli/lib/cli/ide/intellijcommunity_user_pref_dir.rb
+++ b/cli/lib/cli/ide/intellijcommunity_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "13"
+        "14"
       end
     end
   end


### PR DESCRIPTION
related to issue #8 -- since 14 has been out for a few weeks, let's switch to 14 as the default. IntelliJ seems to defer creating the Preferences directory until the IDE is first opened, so this seems to be the easiest way currently to have `brew cask install intellij-idea` followed by `ide_prefs --ide=intellij install` work as expected.
