### PR TITLE
Fix issue with deriving relative paths in Ruby 2.2

### DIFF
--- a/cli/lib/cli/configuration/repo_configuration.rb
+++ b/cli/lib/cli/configuration/repo_configuration.rb
@@ -19,14 +19,20 @@ class Cli::Configuration::RepoConfiguration
   end
 
   def backup_prefs_repo_location
-    @backup_prefs_repo_location || Dir[File.join(@backups_location_base, @ide_name)].first
+    @backup_prefs_repo_location || case_sensitive_filename(@backups_location_base)
   end
 
   def pivotal_prefs_repo_location
-    @pivotal_prefs_repo_location || Dir[File.join(@pivotal_prefs_location_base, @ide_name)].first
+    @pivotal_prefs_repo_location || case_sensitive_filename(@pivotal_prefs_location_base)
   end
 
   def user_prefs_repo_location
     @user_prefs_repo_location
+  end
+
+  private
+
+  def case_sensitive_filename(location_base)
+    Dir[File.join(location_base, @ide_name)].first
   end
 end

--- a/cli/lib/cli/configuration/repo_configuration.rb
+++ b/cli/lib/cli/configuration/repo_configuration.rb
@@ -19,11 +19,11 @@ class Cli::Configuration::RepoConfiguration
   end
 
   def backup_prefs_repo_location
-    @backup_prefs_repo_location || File.join(@backups_location_base, @ide_name)
+    @backup_prefs_repo_location || Dir[File.join(@backups_location_base, @ide_name)].first
   end
 
   def pivotal_prefs_repo_location
-    @pivotal_prefs_repo_location || File.join(@pivotal_prefs_location_base, @ide_name)
+    @pivotal_prefs_repo_location || Dir[File.join(@pivotal_prefs_location_base, @ide_name)].first
   end
 
   def user_prefs_repo_location

--- a/persistence/lib/persistence/private/file_database.rb
+++ b/persistence/lib/persistence/private/file_database.rb
@@ -84,7 +84,7 @@ module Persistence
 
       def convert_absolute_paths_to_relative_paths(absolute_paths)
         absolute_paths.map do |file_path|
-          file_path.sub(absolute_path_in_database(separator), "")
+          file_path.sub(Regexp.new(absolute_path_in_database(separator), Regexp::IGNORECASE), "")
         end
       end
 

--- a/persistence/lib/persistence/private/file_database.rb
+++ b/persistence/lib/persistence/private/file_database.rb
@@ -84,8 +84,12 @@ module Persistence
 
       def convert_absolute_paths_to_relative_paths(absolute_paths)
         absolute_paths.map do |file_path|
-          file_path.sub(Regexp.new(absolute_path_in_database(separator), Regexp::IGNORECASE), "")
+          file_path.sub(case_insensitive_path_regex, "")
         end
+      end
+
+      def case_insensitive_path_regex
+        Regexp.new(absolute_path_in_database(separator), Regexp::IGNORECASE)
       end
 
       def separator


### PR DESCRIPTION
When determining what files to create symlinks for, there is a 'sub'
statement that peels off the root of a filepath to derive a relative
path. This works in Ruby 2.1, because both of the paths happen to be
lowercase, but a fix in Ruby 2.2 has broken it.

Namely, if you had a file called `Filename` (note the case) this
behavior changed:
```
# (Ruby 2.1)
Dir['filename'] #=> ['filename']

# (Ruby 2.2)
Dir['filename'] #=> ['Filename']
```

Now, we ensure that the path for "pref_sources/RubyMine" has the correct
case, AND change the path sub code to be case insensitive.