### PR TITLE
add key binding for EditorMatchBrace

### DIFF
--- a/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
+++ b/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
@@ -6,6 +6,10 @@
   <action id="CloseAllEditorsButActive">
     <keyboard-shortcut first-keystroke="shift meta W" />
   </action>
+  <action id="EditorMatchBrace">
+    <keyboard-shortcut first-keystroke="control meta alt OPEN_BRACKET" />
+    <keyboard-shortcut first-keystroke="control meta alt CLOSE_BRACKET" />
+  </action>
   <action id="Macro.run whole test file">
     <keyboard-shortcut first-keystroke="control meta alt R" />
   </action>


### PR DESCRIPTION
Hi Matt.

I'm Tom Meyer, a Pivot in Palo Alto. Chris Jobst and I thought it would be nice to have a key binding for moving between matching braces in Intellij. For this we've picked "mash" plus either bracket key (ctrl-opt-cmd-] and ctrl-opt-cmd-[ ). We thought this would be a good choice, but if you have other ideas let us know.

Thanks!