### PR TITLE
Update default WebStorm version from 9 to 10

### DIFF
--- a/cli/lib/cli/ide/webstorm_user_pref_dir.rb
+++ b/cli/lib/cli/ide/webstorm_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "9"
+        "10"
       end
     end
   end


### PR DESCRIPTION
WebStorm updated to 10 a handful of months ago, so a fresh install of WebStorm won't work with the pivotal_ide_prefs