### PR TITLE
Set Android Studio's default version to 1.3

### DIFF
--- a/cli/lib/cli/ide/androidstudio_user_pref_dir.rb
+++ b/cli/lib/cli/ide/androidstudio_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        ""
+        "1.3"
       end
     end
   end


### PR DESCRIPTION
Android Studio's default preferences directory includes the version
number with a period. We should use that directory for symlinking.