### PR TITLE
Removes 'should ' from the `it` live template

### DIFF
--- a/pref_sources/WebStorm/templates/jasmine.xml
+++ b/pref_sources/WebStorm/templates/jasmine.xml
@@ -112,7 +112,7 @@
       <option name="OTHER" value="false" />
     </context>
   </template>
-  <template name="it" value="it(&quot;should $B$&quot;, function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
+  <template name="it" value="it(&quot;$B$&quot;, function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
     <variable name="B" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="false" />


### PR DESCRIPTION
The trend for BDD style examples is to prefer 'it does stuff' to 'it should do
stuff'.  Regardless, removing the 'should ' from the live template allows
either pattern to be more easily used. It is still available in the deprecated
`jit` template.