### PR TITLE
Bump default RubyMine version to the new 2016.1

### DIFF
--- a/cli/lib/cli/ide/rubymine_user_pref_dir.rb
+++ b/cli/lib/cli/ide/rubymine_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "80"
+        "2016.1"
       end
     end
   end


### PR DESCRIPTION
- Now creates ~/Library/Preferences/RubyMine2016.1
- Works around a problem with fresh installs of  [sprout-jetbrains-editors::rubymine](https://github.com/pivotal-sprout/sprout-jetbrains-editors) not being able to import ~/Library/Preferences/RubyMine80 when RubyMine is first opened, even if you manually specify it. 

