### PR TITLE
List commands in `--help` message

### DIFF
--- a/cli/bin/ide_prefs.rb
+++ b/cli/bin/ide_prefs.rb
@@ -19,6 +19,8 @@ repo_config_options = {}
 logging_options = {log_level: :info}
 
 OptionParser.new do |opts|
+  opts.banner = "Usage: ide_prefs [options] [install,uninstall]"
+
   opts.on(
       "--ide=IDE",
       ["webstorm", "intellij", "intellijcommunity", "rubymine", "appcode", "androidstudio", "pycharm"],


### PR DESCRIPTION
The help message when you don't include a command (`You must specify a command. Run --help for more information.`) implies that the commands are listed in the default help message. But they aren't there, until now!

A better approach may be to have CommandFactory list out all known commands as it's responsible for looking a command up. 
I'd be happy to pair on that sometime if someone would like, but as the number of commands doesn't seem to change often, this seems reasonable to start with.