### PR TITLE
Default IntelliJ version is 2016.3

### DIFF
--- a/cli/lib/cli/ide/intellij_user_pref_dir.rb
+++ b/cli/lib/cli/ide/intellij_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "15"
+        "2016.3"
       end
     end
   end


### PR DESCRIPTION
2016.3 was released on November 22, 2016

Signed-off-by: Kalai Wei <kawei@pivotal.io>