### PR TITLE
Allow installing from root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Then, run the following commands:
 
 ```sh
 git clone https://github.com/pivotal/pivotal_ide_prefs
-cd pivotal_ide_prefs/cli
-bin/ide_prefs --ide=[rubymine,intellij,intellijcommunity,webstorm,androidstudio,appcode,clion,pycharm] install
+cd pivotal_ide_prefs
+cli/bin/ide_prefs install --ide=intellij
+# ide flag can be any of [rubymine,intellij,intellijcommunity,webstorm,androidstudio,appcode,clion,pycharm]
 ```
 
 This will install the preferences into your IDE of choice. 

--- a/cli/bin/ide_prefs.rb
+++ b/cli/bin/ide_prefs.rb
@@ -5,10 +5,13 @@ unless RUBY_VERSION.to_i >= 2
   exit 1
 end
 
-$LOAD_PATH.unshift "../ide_prefs/lib"
-$LOAD_PATH.unshift "../persistence/lib"
-$LOAD_PATH.unshift "../logging/lib"
-$LOAD_PATH.unshift "lib"
+bin_dir = File.dirname(__FILE__)
+root_dir = File.join(bin_dir, '..', '..')
+
+$LOAD_PATH.unshift "#{root_dir}/ide_prefs/lib"
+$LOAD_PATH.unshift "#{root_dir}/persistence/lib"
+$LOAD_PATH.unshift "#{root_dir}/logging/lib"
+$LOAD_PATH.unshift "#{root_dir}/cli/lib"
 
 require "optparse"
 require "ide_prefs"

--- a/cli/features/acceptance/features/ide_prefs_cli.rb
+++ b/cli/features/acceptance/features/ide_prefs_cli.rb
@@ -35,9 +35,17 @@ module Acceptance
 
         def run
           Bundler.with_clean_env do
-            Open3.popen3("bin/ide_prefs --ide rubymine --backup-prefs-location=#{backup_prefs_location} --user-prefs-location tmp/RubyminePrefs #{command_name}",) do |stdin, stdout, stderr, wait_thr|
-              @exit_status = wait_thr.value
-              @output = stdout.read.chomp + stderr.read.chomp
+            Dir.chdir '..' do
+              Open3.popen3(
+                "cli/bin/ide_prefs" +
+                " --ide rubymine" +
+                " --backup-prefs-location=#{backup_prefs_location}" +
+                " --user-prefs-location cli/tmp/RubyminePrefs" +
+                " #{command_name}"
+              ) do |stdin, stdout, stderr, wait_thr|
+                @exit_status = wait_thr.value
+                @output = stdout.read.chomp + stderr.read.chomp
+              end
             end
           end
         end


### PR DESCRIPTION
Some of us in San Francisco (read: just Tim Jarratt) find it really
frustrating to remember to run the install / uninstall script
from the cli directory.

What if we could just have the tool know how to find the correct
directory, instead of forcing users to remember?

With this change, you can run the install script from any directory,
including the project root, the cli directory (as before), or really
any directory you want.

Changes:
* improve example usage in README
* change ide_prefs to look relative to itself, not working directory
* small whitespace changes to IDE Prefs cli feature test helper