### PR TITLE
Fix for jetbrains 2016.3

### DIFF
--- a/pref_sources/AppCode/keymaps/Pivotal AppCode.xml
+++ b/pref_sources/AppCode/keymaps/Pivotal AppCode.xml
@@ -1,4 +1,4 @@
-<keymap version="1" name="Pivotal AppCode" parent="Pivotal Common">
+<keymap version="1" name="Pivotal AppCode" parent="PivotalCommon">
   <action id="Back">
     <keyboard-shortcut first-keystroke="meta open_bracket" />
     <keyboard-shortcut first-keystroke="meta alt left" />

--- a/pref_sources/Clion/keymaps/Pivotal Clion.xml
+++ b/pref_sources/Clion/keymaps/Pivotal Clion.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keymap version="1" name="Pivotal Clion" parent="Pivotal Common" />
+<keymap version="1" name="Pivotal Clion" parent="PivotalCommon" />
 

--- a/pref_sources/IntelliJ/keymaps/Pivotal IntelliJ.xml
+++ b/pref_sources/IntelliJ/keymaps/Pivotal IntelliJ.xml
@@ -1,4 +1,4 @@
-<keymap version="1" name="Pivotal IntelliJ" parent="Pivotal Common">
+<keymap version="1" name="Pivotal IntelliJ" parent="PivotalCommon">
   <action id="org.jetbrains.plugins.ruby.tasks.rake.actions.RakeTasksPopupAction">
     <keyboard-shortcut first-keystroke="alt r" />
   </action>

--- a/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
+++ b/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
@@ -1,4 +1,4 @@
-<keymap version="1" name="Pivotal Common" parent="Mac OS X 10.5+">
+<keymap version="1" name="PivotalCommon" parent="Mac OS X 10.5+">
   <action id="CloseAllEditors">
     <keyboard-shortcut first-keystroke="meta alt w" />
   </action>

--- a/pref_sources/PyCharm/keymaps/Pivotal PyCharm.xml
+++ b/pref_sources/PyCharm/keymaps/Pivotal PyCharm.xml
@@ -1,4 +1,4 @@
-<keymap version="1" name="Pivotal PyCharm" parent="Pivotal Common">
+<keymap version="1" name="Pivotal PyCharm" parent="PivotalCommon">
   <action id="CloseOtherEditors">
     <keyboard-shortcut first-keystroke="shift ctrl w" />
   </action>

--- a/pref_sources/RubyMine/keymaps/Pivotal RubyMine.xml
+++ b/pref_sources/RubyMine/keymaps/Pivotal RubyMine.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keymap version="1" name="Pivotal RubyMine" parent="Pivotal Common" />
+<keymap version="1" name="Pivotal RubyMine" parent="PivotalCommon" />
 

--- a/pref_sources/WebStorm/keymaps/Pivotal WebStorm.xml
+++ b/pref_sources/WebStorm/keymaps/Pivotal WebStorm.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keymap version="1" name="Pivotal WebStorm" parent="Pivotal Common" />
+<keymap version="1" name="Pivotal WebStorm" parent="PivotalCommon" />
 


### PR DESCRIPTION
Fixes JetBrains 2016.3 inability to have a space in the name of a keymap file

Resolves issue https://github.com/pivotal/pivotal_ide_prefs/issues/48

JetBrains claims that this is fixed is 2017.1 version, please revert this commit when the new product is released