### PR TITLE
Improves key bindings to split editor windows

### DIFF
--- a/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
+++ b/pref_sources/Jetbrains/keymaps/Pivotal Common.xml
@@ -16,14 +16,14 @@
     <keyboard-shortcut first-keystroke="shift ctrl meta alt left" />
     <keyboard-shortcut first-keystroke="shift ctrl meta alt right" />
   </action>
-  <action id="Resume">
-    <keyboard-shortcut first-keystroke="f9" />
-  </action>
-  <action id="SplitHorizontally">
+  <action id="MoveTabDown">
     <keyboard-shortcut first-keystroke="shift ctrl meta alt down" />
   </action>
-  <action id="SplitVertically">
+  <action id="MoveTabRight">
     <keyboard-shortcut first-keystroke="shift ctrl meta alt up" />
+  </action>
+  <action id="Resume">
+    <keyboard-shortcut first-keystroke="f9" />
   </action>
   <action id="SwitchApply">
     <keyboard-shortcut first-keystroke="ctrl alt enter" />


### PR DESCRIPTION
Rathern than using 'SplitVertically/Horizontally' which duplicates the
current editor tap into a new split, we are using the
'MoveTabRight/Down' which creates the split and moves the current tab to
the new split.