### PR TITLE
Add IntelliJ JUnit live templates for Kotlin

### DIFF
--- a/pref_sources/IntelliJ/templates/kotlin-junit.xml
+++ b/pref_sources/IntelliJ/templates/kotlin-junit.xml
@@ -1,0 +1,32 @@
+<templateSet group="Kotlin-JUnit">
+  <template name="test" value="@org.junit.Test&#10;fun `$1$`() {&#10;    $END$&#10;}" description="Kotlin JUnit test" toReformat="true" toShortenFQNames="true">
+    <variable name="1" expression="" defaultValue="&quot;it should&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="KOTLIN_CLASS" value="true" />
+    </context>
+  </template>
+  <template name="aft" value="@org.junit.After&#10;fun $1$() {&#10;    $END$&#10;}" description="Kotlin JUnit After" toReformat="true" toShortenFQNames="true">
+    <variable name="1" expression="" defaultValue="&quot;tearDown&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="KOTLIN_CLASS" value="true" />
+    </context>
+  </template>
+  <template name="aftc" value="companion object {&#10;    @org.junit.AfterClass&#10;    @JvmStatic&#10;    fun $1$() {&#10;        $END$&#10;    }&#10;}" description="Kotlin JUnit AfterClass" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="1" expression="" defaultValue="&quot;tearDownClass&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="KOTLIN_CLASS" value="true" />
+    </context>
+  </template>
+  <template name="befc" value="companion object {&#10;    @org.junit.BeforeClass&#10;    @JvmStatic&#10;    fun $1$() {&#10;        $END$&#10;    }&#10;}" description="Kotlin JUnit BeforeClass" toReformat="true" toShortenFQNames="true">
+    <variable name="1" expression="" defaultValue="&quot;setUpClass&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="KOTLIN_CLASS" value="true" />
+    </context>
+  </template>
+  <template name="bef" value="@org.junit.Before&#10;fun $1$() {&#10;    $END$&#10;}" description="Kotlin JUnit Before" toReformat="true" toShortenFQNames="true">
+    <variable name="1" expression="" defaultValue="&quot;setUp&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="KOTLIN_CLASS" value="true" />
+    </context>
+  </template>
+</templateSet>


### PR DESCRIPTION
Added the basic JUnit live templates, but for Kotlin.

It has :
- test
- aft
- aftc
- bef
- befc

Please note that aftc and befc are not perfect : to make them JVM-static, they are put in a "companion object". However, there can only be one per class. Therefore, should you use both in one class, you will have to merge both companion objects manually.