### PR TITLE
Update Goland to latest version

### DIFF
--- a/cli/lib/cli/ide/gogland_user_pref_dir.rb
+++ b/cli/lib/cli/ide/gogland_user_pref_dir.rb
@@ -4,11 +4,11 @@ module Cli
   module Ide
     class GoglandUserPrefDir < JetBrainsIdeUserPrefDir
       def ide_pref_dir_name_without_version
-        "Gogland"
+        "GoLand"
       end
 
       def default_ide_pref_dir_version
-        "1.0"
+        "2017.3"
       end
     end
   end


### PR DESCRIPTION
I'd really like to be able to make this process nicer in the future.

What do y'all think about a future PR that would enable pivotal_ide_prefs to look inside the `/Users/__name__/Library/Preferences` directory and more intelligently discover the correct directory to install the preferences into ? Would this feature be considered useful ?

For example, given that the directory `/Users/leftsaidtim/Library/Preferences/Goland2018.1` exists, I would want to see the ide prefs installed when I run `cli/bin/ide_prefs install --ide=go`.